### PR TITLE
Bugfix: Support _order_ and _ignore_

### DIFF
--- a/matrix_enum/matrix_enum.py
+++ b/matrix_enum/matrix_enum.py
@@ -119,7 +119,7 @@ class _MatrixEnumMeta(EnumMeta):
                     reversed_addressable[item] = value
 
             # Callables are 'special' in that they get bound rather than member'd by the enum.
-            elif key not in ('__module__', '__metaclass__', '__doc__', '__qualname__') \
+            elif key not in ('__module__', '__metaclass__', '__doc__', '__qualname__', '_order_', '_ignore_')\
                     and not (callable(value) or isinstance(value, classmethod)):
                 raise ValueError('{} is not a Member'.format(value))
 


### PR DESCRIPTION
## Problem/ Feature Summary

Respect the use of `_order_` and `_ignore_`.

Per https://docs.python.org/3/library/enum.html#supported-sunder-names, there are a handful `_sunder_`s we error on here. The other noted sunders appear that they'll be callables which we'll already handle

## Change Overview

* `~` - Do not enforce that the stated sunders are `Members` 
* `+` - Tests that run checks against various python versions

## Examples

The following will no longer error in all supported versions

```python
class Enum(MatrixEnum):
    _order_ = 'TWO ONE'
    TWO = Member(code=2)
    ONE = Member(code=1)
```

The following will no longer error in 3.7+ (where it was introduced)

```python
class IgnoredEnum(MatrixEnum):
    _ignore_ = 'IGNORE_ME'
    ONE = Member(code=1)
    TWO = Member(code=2)
    IGNORE_ME = Member(code=3)
```

## Checklist

- [x] I've filled out all sections of the template above.
- [ ] I've added an entry to the `[Unreleased]` section of the [CHANGELOG.md](../CHANGELOG.md) using the guidelines [here](https://keepachangelog.com/en/1.0.0/).
^ Skipped until a 1.0 release
- [x] I've added tests for any new or updated code.
