### PR TITLE
Backrev version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [1.1.0] - 2020-12-04
 - MatrixEnums can now be looked up by member name using the same syntax as other lookups.
 - Improved MatrixEnum compile-time validation error messages.
 

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ with open(path.join(this_directory, 'README.md')) as f:
 
 setup(
     name='matrix_enum',
-    version='1.0.0',
+    version='1.1.0',
     url='https://github.com/klaviyo/matrix_enum',
     author='Klaviyo',
     description='Data structure for multi-dimensional enums',


### PR DESCRIPTION
Missed a version rev for 1.1.0 (made it on my local checkout, but didn't push before merging).